### PR TITLE
Fix patches/graphql-extensions+0.1.3.patch

### DIFF
--- a/patches/graphql-extensions+0.1.3.patch
+++ b/patches/graphql-extensions+0.1.3.patch
@@ -1,6 +1,6 @@
 patch-package
---- a/node_modules/graphql-extensions/dist/index.d.ts
-+++ b/node_modules/graphql-extensions/dist/index.d.ts
+--- a/node_modules/graphql-extensions/dist/index.d.ts~	2021-09-06 15:13:29.000000000 +0300
++++ b/node_modules/graphql-extensions/dist/index.d.ts	2021-09-06 15:14:18.000000000 +0300
 @@ -18,6 +18,7 @@ export declare class GraphQLExtension<TContext = any> {
          };
          persistedQueryHit?: boolean;
@@ -28,13 +28,13 @@ patch-package
      }): EndHandler;
      parsingDidStart(o: {
          queryString: string;
-@@ -60,8 +64,10 @@ export declare class GraphQLExtensionStack<TContext = any> {
+@@ -64,8 +64,10 @@
      }): EndHandler;
      willSendResponse(o: {
          graphqlResponse: GraphQLResponse;
 +        context: TContext;
      }): {
-         graphqlResponse: GraphQLResponse; 
+         graphqlResponse: GraphQLResponse;
 +        context: TContext;
      };
      willResolveField(source: any, args: {


### PR DESCRIPTION
It didn't apply, so re-created it.

<del>Must be some whitespace issue, but I don't see the difference visually... it's not a space/tab or trailing space issue. totally odd.</del>

EDIT: it's a trailing whitespace issue that got lost when the patch was committed initially.